### PR TITLE
fix: fixed make_request attempting to convert list to string

### DIFF
--- a/osu/asyncio/http.py
+++ b/osu/asyncio/http.py
@@ -39,7 +39,7 @@ class AsynchronousHTTPHandler:
             raise ScopeException(f"You don't have the {scope_required} scope, which is required to do this action.")
 
         headers = self.get_headers(path.requires_auth, **headers)
-        params = {str(key): str(value) for key, value in kwargs.items() if value is not None}
+        params = {str(key): value for key, value in kwargs.items() if value is not None}
 
         async with aiohttp.ClientSession() as session:
             async with session.request(method, base_url + path.path, headers=headers, data=data, params=params) as resp:

--- a/osu/http.py
+++ b/osu/http.py
@@ -38,7 +38,7 @@ class HTTPHandler:
             raise ScopeException(f"You don't have the {scope_required} scope, which is required to do this action.")
 
         headers = self.get_headers(path.requires_auth, **headers)
-        params = {str(key): str(value) for key, value in kwargs.items() if value is not None}
+        params = {str(key): value for key, value in kwargs.items() if value is not None}
         response = getattr(requests, method)(base_url + path.path, headers=headers, data=data, params=params)
         self.rate_limit.request_used()
         response.raise_for_status()


### PR DESCRIPTION
Fixes a bug in `Client.make_request()` and `AsynchronousClient.make_request()` that made list parameters like `Client.get_beatmaps([123, 727, 999])` not unfold and be sent as 
```
{
    "ids[]": "[123, 727, 999]"
}
```
instead of 
```
{
    "ids[]": [123, 727, 999]
}
```
as in the picture 
![image](https://user-images.githubusercontent.com/64037726/182562620-d37113a1-3f89-4cac-9eb4-8c9fef151ae2.png)

(tests work and will be delivered soon)