### PR TITLE
Add before, after and limit parameters for `get_match`

### DIFF
--- a/osu/asyncio/client.py
+++ b/osu/asyncio/client.py
@@ -1569,7 +1569,7 @@ class AsynchronousClient:
         )
         return GetMatchesResult(list(map(Match, resp["matches"])), resp["params"], resp["cursor"])
 
-    async def get_match(self, match_id: int) -> MatchExtended:
+    async def get_match(self, match_id: int, before: Optional[int] = None, after: Optional[int] = None, limit: Optional[int] = None) -> MatchExtended:
         """
         Returns a match by id.
 
@@ -1580,11 +1580,20 @@ class AsynchronousClient:
         match_id: int
             The match id.
 
+        before: Optional[int]
+            Filter for match events before the specified MatchEvent.id.
+
+        after: Optional[int]
+            Filter for match events after the specified MatchEvent.id.
+
+        limit: Optional[int]
+            Maximum number of match events to return. 100 default, 101 maximum.
+
         **Returns**
 
         :class:`Match`
         """
-        return MatchExtended(await self.http.make_request(Path.get_match(match_id)))
+        return MatchExtended(await self.http.make_request(Path.get_match(match_id), before=before, after=after, limit=limit))
 
     async def get_rooms(
         self,

--- a/osu/client.py
+++ b/osu/client.py
@@ -1575,7 +1575,7 @@ class Client:
         resp = self.http.make_request(Path.get_matches(), limit=limit, sort=sort, **{"cursor[match_id]": match_id})
         return GetMatchesResult(list(map(Match, resp["matches"])), resp["params"], resp["cursor"])
 
-    def get_match(self, match_id: int) -> MatchExtended:
+    def get_match(self, match_id: int, before: Optional[int] = None, after: Optional[int] = None, limit: Optional[int] = None) -> MatchExtended:
         """
         Returns a match by id.
 
@@ -1586,11 +1586,20 @@ class Client:
         match_id: int
             The match id.
 
+        before: Optional[int]
+            Filter for match events before the specified MatchEvent.id.
+
+        after: Optional[int]
+            Filter for match events after the specified MatchEvent.id.
+
+        limit: Optional[int]
+            Maximum number of match events to return. 100 default, 101 maximum.
+
         **Returns**
 
         :class:`Match`
         """
-        return MatchExtended(self.http.make_request(Path.get_match(match_id)))
+        return MatchExtended(self.http.make_request(Path.get_match(match_id), before=before, after=after, limit=limit))
 
     def get_rooms(
         self,


### PR DESCRIPTION
Without these parameters, matches with more than 100 events will only have their latest 100 events returned.

Corresponding documentation: https://osu.ppy.sh/docs/index.html#get-match

Reference code:

```python
def get_match_info(match_id: int) -> tuple[osu.Match, list[osu.match.MatchEvent]]:
    match = client.get_match(match_id)
    # Trace back for more events before match.events[0].id
    events = match.events
    first_event_id = events[0].id
    # Get events before the first event
    while first_event_id != match.first_event_id:
        response = client.get_match(match_id, before=first_event_id)
        if len(response.events) == 0:
            break
        # Prepend the events to the list
        events = response.events + events
        # Update the first event id
        first_event_id = response.events[0].id
    return match, events
```