### PR TITLE
Fix background_url from raw.jpg to fullsize.jpg to avoid 404

### DIFF
--- a/osu/objects/beatmap.py
+++ b/osu/objects/beatmap.py
@@ -185,7 +185,7 @@ class BeatmapsetCompact:
         self.user_id: int = get_required(data, "user_id")
         self.video: bool = get_required(data, "video")
 
-        self.background_url: str = f"https://assets.ppy.sh/beatmaps/{self.id}/covers/raw.jpg"
+        self.background_url: str = f"https://assets.ppy.sh/beatmaps/{self.id}/covers/fullsize.jpg"
 
         self.availability: BeatmapsetAvailability = get_optional(data, "availability", BeatmapsetAvailability)
         self.beatmaps: Optional[List[BeatmapCompact]] = get_optional_list(data, "beatmaps", BeatmapCompact)


### PR DESCRIPTION
The previously used covers/raw.jpg endpoint now returns 404.

This PR updates background_url to use covers/fullsize.jpg, which correctly returns the full background image.

Tested manually by resolving the generated URL in a browser.